### PR TITLE
ruby: add Linux OpenSSL/libyaml env for rv-ruby versions

### DIFF
--- a/ruby.hcl
+++ b/ruby.hcl
@@ -43,12 +43,25 @@ version "3.2.10" "3.3.9" "3.3.10" "3.4.7" "3.4.8" "4.0.0" "4.0.1" {
     source = "https://github.com/spinel-coop/rv-ruby/releases/download/${rv_release}/ruby-${version}.ventura.tar.gz"
   }
 
+  // rv-ruby statically links OpenSSL into its bundled openssl.so, but gem native
+  // extensions (e.g. the openssl gem) recompile and dynamically link against the
+  // system's libssl. Ubuntu 24.04 ships OpenSSL 3.0.x which is too old for gems
+  // built against rv-ruby's 3.5+ headers. Point gem compilation and runtime at
+  // linuxbrew's OpenSSL, which is present on Blox workstations.
   platform "linux" "amd64" {
     source = "https://github.com/spinel-coop/rv-ruby/releases/download/${rv_release}/ruby-${version}.x86_64_linux.tar.gz"
+    env = {
+      "BUNDLE_BUILD__OPENSSL": "--with-openssl-dir=/home/linuxbrew/.linuxbrew/opt/openssl@3",
+      "LD_LIBRARY_PATH": "/home/linuxbrew/.linuxbrew/opt/openssl@3/lib:/home/linuxbrew/.linuxbrew/opt/libyaml/lib:${LD_LIBRARY_PATH}",
+    }
   }
 
   platform "linux" "arm64" {
     source = "https://github.com/spinel-coop/rv-ruby/releases/download/${rv_release}/ruby-${version}.arm64_linux.tar.gz"
+    env = {
+      "BUNDLE_BUILD__OPENSSL": "--with-openssl-dir=/home/linuxbrew/.linuxbrew/opt/openssl@3",
+      "LD_LIBRARY_PATH": "/home/linuxbrew/.linuxbrew/opt/openssl@3/lib:/home/linuxbrew/.linuxbrew/opt/libyaml/lib:${LD_LIBRARY_PATH}",
+    }
   }
 }
 


### PR DESCRIPTION
rv-ruby statically links OpenSSL and libyaml into its built-in extensions, but gem native extensions recompile and dynamically link against the system libs. Ubuntu 24.04 ships OpenSSL 3.0.x which is too old. Set BUNDLE_BUILD__OPENSSL and LD_LIBRARY_PATH on Linux to use linuxbrew's OpenSSL and libyaml. macOS is unaffected.

Amp-Thread-ID: https://ampcode.com/threads/T-019c9632-b6b8-724a-af79-d30573ba186a